### PR TITLE
Update LICENSE with MIT license and add SPDX identifier

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+SPDX-License-Identifier: MIT
+
 MIT License
 
 Copyright (c) 2025 CipherYuvraj
@@ -9,8 +11,8 @@ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,


### PR DESCRIPTION
Changes made:

- Replaced/updated the existing LICENSE file with the full MIT License text.
- Added SPDX-License-Identifier: MIT to support automated license detection.
- Updated copyright notice to (c) 2025 CipherYuvraj.

Why this matters:

- Ensures the project is officially recognized as MIT-licensed.
- Makes it easier for developers, contributors, and tools to understand and respect licensing terms.
- Strengthens the project’s open-source credibility and usability.